### PR TITLE
Add free API data loader for options module

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,5 +104,33 @@ Aman Raza (electro199#8130) - https://github.com/electro199
 Cyteon (cyteon) - https://github.com/cyteon
 
 
+## Options Trading Module
+
+This repository now includes a minimal **AI-powered options trading module** located in
+`options_trading/`. It provides:
+
+- Black–Scholes, binomial and Monte Carlo pricing
+- Real-time Greek calculations
+- Simple strategy recommendations
+- Skeleton machine learning models for price prediction and volatility forecasting
+- A lightweight backtesting engine
+- Free price data via Yahoo Finance using ``yfinance``
+
+### Running the tests
+
+Install requirements and run `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+The tests validate the Black–Scholes implementation and delta calculation.
+
+### Fetching data with free APIs
+
+The ``options_trading.data.fetch_price_history`` function retrieves historical prices from Yahoo Finance using the open-source ``yfinance`` package.
+
+
 ## LICENSE
 [Roboto Fonts](https://fonts.google.com/specimen/Roboto/about) are licensed under [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)

--- a/options_trading/__init__.py
+++ b/options_trading/__init__.py
@@ -1,0 +1,28 @@
+"""AI-powered options trading utilities."""
+
+from .pricing import OptionContract, black_scholes_price, binomial_price, monte_carlo_price
+from .greeks import calculate_greeks, Greeks
+from .strategies import recommend_strategy, Strategy
+from .ml_models import lstm_price_predictor, VolatilityForecaster
+from .risk import value_at_risk, Portfolio
+from .backtesting import backtest
+from .data import load_price_history, fetch_price_history
+
+__all__ = [
+    "OptionContract",
+    "black_scholes_price",
+    "binomial_price",
+    "monte_carlo_price",
+    "calculate_greeks",
+    "Greeks",
+    "recommend_strategy",
+    "Strategy",
+    "lstm_price_predictor",
+    "VolatilityForecaster",
+    "value_at_risk",
+    "Portfolio",
+    "backtest",
+    "load_price_history",
+    "fetch_price_history",
+]
+

--- a/options_trading/backtesting.py
+++ b/options_trading/backtesting.py
@@ -1,0 +1,19 @@
+"""Simple backtesting engine."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pandas as pd
+
+from .pricing import OptionContract
+
+
+def backtest(prices: pd.Series, strategy_func: Callable[[float], OptionContract]) -> pd.Series:
+    """Run a naive backtest over historical prices."""
+    pnl = []
+    for price in prices:
+        contract = strategy_func(price)
+        pnl.append(price - contract.strike)
+    return pd.Series(pnl, index=prices.index)
+

--- a/options_trading/data.py
+++ b/options_trading/data.py
@@ -1,0 +1,44 @@
+"""Market data utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import yfinance as yf
+
+import pandas as pd
+
+
+def load_price_history(csv_path: Path, symbol: Optional[str] = None) -> pd.Series:
+    """Load historical prices from a CSV file."""
+    df = pd.read_csv(csv_path, parse_dates=["date"])
+    if symbol:
+        df = df[df["symbol"] == symbol]
+    return df.set_index("date")["close"]
+
+
+def fetch_price_history(symbol: str, start: str, end: str, interval: str = "1d") -> pd.Series:
+    """Fetch historical closing prices from Yahoo Finance.
+
+    Parameters
+    ----------
+    symbol: str
+        The ticker symbol to download, e.g. ``"AAPL"``.
+    start: str
+        Start date as ``"YYYY-MM-DD"``.
+    end: str
+        End date as ``"YYYY-MM-DD"``.
+    interval: str, optional
+        Data interval supported by Yahoo Finance. Defaults to ``"1d"``.
+
+    Returns
+    -------
+    pandas.Series
+        Series of closing prices indexed by date.
+    """
+    data = yf.download(symbol, start=start, end=end, interval=interval, progress=False)
+    if "Close" not in data:
+        raise ValueError(f"Failed to fetch data for {symbol}")
+    return data["Close"]
+

--- a/options_trading/greeks.py
+++ b/options_trading/greeks.py
@@ -1,0 +1,45 @@
+"""Greeks calculation for option contracts."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from scipy.stats import norm
+
+from .pricing import OptionContract, _d1, _d2
+
+
+@dataclass
+class Greeks:
+    delta: float
+    gamma: float
+    theta: float
+    vega: float
+    rho: float
+
+
+def calculate_greeks(contract: OptionContract) -> Greeks:
+    """Return the option Greeks using Black-Scholes sensitivities."""
+    d1 = _d1(contract)
+    d2 = _d2(contract)
+    sign = 1 if contract.option_type == "call" else -1
+    delta = sign * norm.cdf(sign * d1)
+    gamma = norm.pdf(d1) / (contract.underlying_price * contract.volatility * math.sqrt(contract.time_to_expiry))
+    theta = (
+        -(
+            contract.underlying_price
+            * norm.pdf(d1)
+            * contract.volatility
+            / (2 * math.sqrt(contract.time_to_expiry))
+        )
+        - sign
+        * contract.risk_free_rate
+        * contract.strike
+        * math.exp(-contract.risk_free_rate * contract.time_to_expiry)
+        * norm.cdf(sign * d2)
+    )
+    vega = contract.underlying_price * norm.pdf(d1) * math.sqrt(contract.time_to_expiry)
+    rho = sign * contract.strike * contract.time_to_expiry * math.exp(-contract.risk_free_rate * contract.time_to_expiry) * norm.cdf(sign * d2)
+    return Greeks(delta=delta, gamma=gamma, theta=theta, vega=vega, rho=rho)
+

--- a/options_trading/ml_models.py
+++ b/options_trading/ml_models.py
@@ -1,0 +1,38 @@
+"""Machine learning models for options trading."""
+
+from __future__ import annotations
+
+from torch import nn
+
+
+def lstm_price_predictor(input_size: int, hidden_size: int = 50, num_layers: int = 2) -> nn.Module:
+    """Return a simple LSTM network for price prediction."""
+
+    class LSTMModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lstm = nn.LSTM(input_size, hidden_size, num_layers, batch_first=True)
+            self.fc = nn.Linear(hidden_size, 1)
+
+        def forward(self, x):
+            out, _ = self.lstm(x)
+            out = out[:, -1, :]
+            return self.fc(out)
+
+    return LSTMModel()
+
+
+class VolatilityForecaster(nn.Module):
+    """A simple neural network for volatility forecasting."""
+
+    def __init__(self, input_size: int, hidden_size: int = 32):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, 1),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+

--- a/options_trading/pricing.py
+++ b/options_trading/pricing.py
@@ -1,0 +1,82 @@
+"""Option pricing models."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.stats import norm
+
+
+@dataclass
+class OptionContract:
+    underlying_price: float
+    strike: float
+    time_to_expiry: float  # in years
+    risk_free_rate: float
+    volatility: float
+    option_type: str  # 'call' or 'put'
+
+
+def _d1(contract: OptionContract) -> float:
+    return (
+        math.log(contract.underlying_price / contract.strike)
+        + (contract.risk_free_rate + 0.5 * contract.volatility ** 2)
+        * contract.time_to_expiry
+    ) / (contract.volatility * math.sqrt(contract.time_to_expiry))
+
+
+def _d2(contract: OptionContract) -> float:
+    return _d1(contract) - contract.volatility * math.sqrt(contract.time_to_expiry)
+
+
+def black_scholes_price(contract: OptionContract) -> float:
+    """Price an option using the Black-Scholes formula."""
+    d1 = _d1(contract)
+    d2 = _d2(contract)
+    if contract.option_type == "call":
+        price = (
+            contract.underlying_price * norm.cdf(d1)
+            - contract.strike * math.exp(-contract.risk_free_rate * contract.time_to_expiry) * norm.cdf(d2)
+        )
+    else:
+        price = (
+            contract.strike * math.exp(-contract.risk_free_rate * contract.time_to_expiry) * norm.cdf(-d2)
+            - contract.underlying_price * norm.cdf(-d1)
+        )
+    return price
+
+
+def binomial_price(contract: OptionContract, steps: int = 100) -> float:
+    """Price an option using a Cox-Ross-Rubinstein binomial tree."""
+    dt = contract.time_to_expiry / steps
+    u = math.exp(contract.volatility * math.sqrt(dt))
+    d = 1 / u
+    p = (math.exp(contract.risk_free_rate * dt) - d) / (u - d)
+    disc = math.exp(-contract.risk_free_rate * dt)
+
+    prices = [contract.underlying_price * (u ** j) * (d ** (steps - j)) for j in range(steps + 1)]
+    if contract.option_type == "call":
+        values = [max(0, price - contract.strike) for price in prices]
+    else:
+        values = [max(0, contract.strike - price) for price in prices]
+
+    for _ in range(steps):
+        values = [disc * (p * values[j + 1] + (1 - p) * values[j]) for j in range(len(values) - 1)]
+    return values[0]
+
+
+def monte_carlo_price(contract: OptionContract, simulations: int = 10000) -> float:
+    """Price an option using Monte Carlo simulation."""
+    dt = contract.time_to_expiry
+    drift = (contract.risk_free_rate - 0.5 * contract.volatility ** 2) * dt
+    diffusion = contract.volatility * math.sqrt(dt)
+    z = np.random.standard_normal(simulations)
+    price = contract.underlying_price * np.exp(drift + diffusion * z)
+    if contract.option_type == "call":
+        payoff = np.maximum(price - contract.strike, 0)
+    else:
+        payoff = np.maximum(contract.strike - price, 0)
+    return math.exp(-contract.risk_free_rate * dt) * np.mean(payoff)
+

--- a/options_trading/risk.py
+++ b/options_trading/risk.py
@@ -1,0 +1,22 @@
+"""Risk management utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+
+@dataclass
+class Portfolio:
+    positions: Sequence[float]
+
+
+def value_at_risk(portfolio_returns: Sequence[float], confidence: float = 0.95) -> float:
+    """Historical simulation VaR."""
+    losses = -np.sort(-np.array(portfolio_returns))
+    index = int((1 - confidence) * len(losses))
+    return losses[index]
+
+

--- a/options_trading/strategies.py
+++ b/options_trading/strategies.py
@@ -1,0 +1,30 @@
+"""Automated options strategy recommendation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .pricing import OptionContract, black_scholes_price
+from .greeks import calculate_greeks
+
+
+@dataclass
+class Strategy:
+    name: str
+    description: str
+    contracts: List[OptionContract]
+
+
+def recommend_strategy(contract: OptionContract) -> Strategy:
+    """Suggest a simple strategy based on volatility and Greeks."""
+    greeks = calculate_greeks(contract)
+    price = black_scholes_price(contract)
+    if greeks.vega > price * 0.1:
+        return Strategy(
+            name="Straddle",
+            description="Buy call and put at the same strike to play volatility",
+            contracts=[contract, OptionContract(**{**contract.__dict__, "option_type": "put"})],
+        )
+    return Strategy(name="Covered Call", description="Hold underlying and sell call", contracts=[contract])
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,6 @@ ffmpeg-python==0.2.0
 elevenlabs==1.3.0
 yt-dlp==2024.5.27
 numpy==1.26.4
+pandas==2.2.2
+scipy==1.12.0
+yfinance==0.2.40

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from options_trading.data import fetch_price_history
+
+
+def test_fetch_price_history():
+    dummy = pd.DataFrame({"Close": [1.0, 2.0]}, index=pd.date_range("2020-01-01", periods=2))
+    with patch("yfinance.download", return_value=dummy) as mock_dl:
+        prices = fetch_price_history("AAPL", "2020-01-01", "2020-01-02")
+        mock_dl.assert_called_once()
+        assert isinstance(prices, pd.Series)
+        assert prices.iloc[0] == 1.0
+

--- a/tests/test_greeks.py
+++ b/tests/test_greeks.py
@@ -1,0 +1,22 @@
+import math
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from options_trading.pricing import OptionContract
+from options_trading.greeks import calculate_greeks
+
+
+def test_delta_call():
+    contract = OptionContract(
+        underlying_price=100,
+        strike=100,
+        time_to_expiry=1,
+        risk_free_rate=0.05,
+        volatility=0.2,
+        option_type="call",
+    )
+    greeks = calculate_greeks(contract)
+    assert math.isclose(greeks.delta, 0.636, rel_tol=1e-2)
+

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,22 @@
+import math
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from options_trading.pricing import OptionContract, black_scholes_price
+
+
+def test_black_scholes_call():
+    contract = OptionContract(
+        underlying_price=100,
+        strike=100,
+        time_to_expiry=1,
+        risk_free_rate=0.05,
+        volatility=0.2,
+        option_type="call",
+    )
+    price = black_scholes_price(contract)
+    # Known analytic value for parameters above is around 10.45
+    assert math.isclose(price, 10.45, rel_tol=1e-2)
+


### PR DESCRIPTION
## Summary
- expose `fetch_price_history` and document Yahoo Finance usage
- integrate free data loader in options trading utilities
- update requirements with yfinance
- provide unit test for the new function
- fix unused imports

## Testing
- `python3 -m pip install numpy pandas scipy torch --extra-index-url https://download.pytorch.org/whl/cpu`
- `python3 -m pip install yfinance`
- `ruff check options_trading tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68426cde01e48326a71c06827b0331b0